### PR TITLE
add support for `base` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,25 @@ decide how the mappings of key -> actual URL work.
     http2-push-manifest -f path/to/site/index.html -m push.json
     http2-push-manifest -f path/to/site/index.html --manifest push.json
 
+**Example** - providing a base path
+
+    http2-push-manifest -b path/to/site -f path/to/site/elements/index.html
+    
+Specifying a base path causes file paths to be generated relative to the base:
+
+    {
+      "elements/index.html": {
+        "/elements/css/app.css": {
+          "type": "style",
+          "weight": 1
+        },
+        ...
+      },
+      ...
+    }
+
+ 
+
 ## Usage on App Engine
 
 If you're using App Engine for your server, check out [http2push-gae](https://github.com/GoogleChrome/http2push-gae). It leverages this manifest file format and automagically reads

--- a/bin/http2-push-manifest
+++ b/bin/http2-push-manifest
@@ -111,7 +111,7 @@ function writeManifest(manifest, opt_content) {
   console.log(`Wrote ${manifest.name}`);
 }
 
-function generateManifest(manifestName, files, singleFile) {
+function generateManifest(manifestName, basePath, files, singleFile) {
   if (!files.length) {
     let manifest = new Manifest({name: manifestName});
     writeManifest(manifest, jsonOutput);
@@ -125,8 +125,7 @@ function generateManifest(manifestName, files, singleFile) {
     f = `.${path.sep}${f}`;
   }
 
-  let basePath = f.slice(0, f.lastIndexOf(path.sep))
-  let inputPath = f.slice(f.lastIndexOf(path.sep) + 1);
+  let inputPath = path.relative(basePath, f);
 
   if (!basePath || !inputPath) {
     printHelp();
@@ -144,7 +143,7 @@ function generateManifest(manifestName, files, singleFile) {
 
     // Remove processed file from list and proceed with next.
     files.shift();
-    generateManifest(manifestName, files, singleFile);
+    generateManifest(manifestName, basePath, files, singleFile);
   }).catch(err => {
     console.warn(err);
   });
@@ -154,15 +153,18 @@ let args = nopt({
   help: Boolean,
   version: Boolean,
   manifest: String,
-  file: [String, Array]
+  file: [String, Array],
+  base: String
 }, {
   'h': ['--help'],
   'v': ['--version'],
   'm': ['--manifest'],
-  'f': ['--file']
+  'f': ['--file'],
+  'b': ['--base']
 });
 
 let files = args.file || [];
+let base = args.base || '.';
 let manifestName = args.manifest;
 // let basePath = args.argv.remain[0];
 // let inputPath = args.argv.remain[1];
@@ -179,6 +181,6 @@ if (args.help || !files.length) {
 
 notifyIfUpdateAvailable(); // Let user know if there's a newer version.
 
-generateManifest(manifestName, files, files.length < 2);
+generateManifest(manifestName, base, files, files.length < 2);
 
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -141,6 +141,7 @@ suite('cli', () => {
   var exec = require('child_process').exec;
 
   let CMD =  `${__dirname}/../bin/http2-push-manifest`;
+  let BASE = `${__dirname}/html`;
   let INPUT = `${__dirname}/html/basic.html`;
   let INPUT2 = `${__dirname}/html/basic2.html`;
   let NAME = 'push_manifest.json';
@@ -174,7 +175,7 @@ suite('cli', () => {
   });
 
   test('multi manifest', done => {
-    process(`${CMD} -f ${INPUT} -f ${INPUT2}`,  stdout => {
+    process(`${CMD} -b ${BASE} -f ${INPUT} -f ${INPUT2}`,  stdout => {
       assert(fs.statSync(NAME).isFile(), 'multi file manifest written');
 
       fs.readFile(NAME, (err, data) => {
@@ -192,4 +193,26 @@ suite('cli', () => {
       });
     });
   });
+
+  test('manifest without base argument', done => {
+    process(`${CMD} -f ${INPUT} -f ${INPUT2}`,  stdout => {
+      assert(fs.statSync(NAME).isFile(), 'multi file manifest written');
+
+      fs.readFile(NAME, (err, data) => {
+        assert(!err, 'error reading multi file manifest');
+
+        var json = JSON.parse(data);
+
+        var inputPath = path.basename(__dirname) + '/' + path.relative(__dirname, INPUT);
+
+        // check that the top-level file name is relative to the current directory
+        assert(inputPath in json);
+
+        fs.unlinkSync(NAME); // cleanup
+
+        done();
+      });
+    });
+  });
+
 });


### PR DESCRIPTION
Eric, thanks for providing this utility. Unfortunately it seems to assume that all components are located in the same folder, as it failed to include components referenced by my main component that were located in other folders. I modified it to allow for a `base` path argument to use as a base for relative URLs, and this seems to have solved the issue.

Of course it's very possible that I'm doing something wrong or that there's a better way of solving the problem.
